### PR TITLE
Support absolute url for background image

### DIFF
--- a/templates/keydown.scss.erb
+++ b/templates/keydown.scss.erb
@@ -105,7 +105,7 @@ body {
 
       <% backgrounds.each do |background| %>
       &.<%= background[:classname] %> {
-          background-image: url(../<%= background[:path] %>);
+          background-image: url(<%= (background[:path][0,2] === '//' ? '' : '../') + background[:path] %>);
       }
       <% end %>
 


### PR DESCRIPTION
With this fix, `}}} //github.com/favicon.ico` generates `background-image: url(//github.com/favicon.ico)` instead of `background-image: url(..///github.com/favicon.ico)`.